### PR TITLE
Update auto-assign to enable node v16

### DIFF
--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -7,4 +7,4 @@ jobs:
     name: Auto Assign
     runs-on: ubuntu-latest
     steps:
-      - uses: kentaro-m/auto-assign-action@v1.2.0
+      - uses: kentaro-m/auto-assign-action@v1.2.5

--- a/.github/workflows/link-ticket.yml
+++ b/.github/workflows/link-ticket.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     types: [opened, ready_for_review]
 
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   link_ticket:
@@ -20,7 +23,7 @@ jobs:
           if [[ ${{ github.head_ref }} =~ ^[A-Za-z]+-[0-9]+ ]]; then
               echo ::set-output name=match::true
           fi
-      - uses: tzkhan/pr-update-action@v2
+      - uses: the-wright-jamie/update-pr-info-action@v1
         if: steps.check-for-ticket.outputs.match == 'true'
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/link-ticket.yml
+++ b/.github/workflows/link-ticket.yml
@@ -16,12 +16,12 @@ jobs:
     steps:
       - name: Clean title
         id: clean_title
-        run: echo ::set-output name=title::$( echo '${{ github.event.pull_request.title }}' | sed 's/[A-Za-z][A-Za-z]*\s*[\/-]*[0-9][0-9]*[\/-:]*//')
+        run: echo "title=$( echo '${{ github.event.pull_request.title }}' | sed 's/[A-Za-z][A-Za-z]*\s*[\/-]*[0-9][0-9]*[\/-:]*//')"
       - name: Check for Ticket
         id: check-for-ticket
         run: |
           if [[ ${{ github.head_ref }} =~ ^[A-Za-z]+-[0-9]+ ]]; then
-              echo ::set-output name=match::true
+              echo "match=true" >> $GITHUB_OUTPUT
           fi
       - uses: the-wright-jamie/update-pr-info-action@v1
         if: steps.check-for-ticket.outputs.match == 'true'


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX181rfwGhMhdY0SekJmnl4Inpb2nrECww%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=r9Dm-Rn)

Resolves the following:
```
 Node.js 12 actions are deprecated. 
Please update the following actions to use Node.js 16: tzkhan/pr-update-action@v2.
For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

Warning: The `set-output` command is deprecated and will be disabled soon.
Please upgrade to using Environment Files.
For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

Warning jobs:
[Link Ticket / Link Ticket](https://github.com/flocasts/trackwrestling-api/actions/runs/4576668307/jobs/8081104336)


See: 

- https://github.com/kentaro-m/auto-assign-action/issues/99 and linked items
- https://github.com/tzkhan/pr-update-action/issues/36 and https://github.com/the-wright-jamie/Update-PR-Info-Action